### PR TITLE
Default server should be http (vs https) as the install directions do…

### DIFF
--- a/client/patchman-client.conf
+++ b/client/patchman-client.conf
@@ -1,5 +1,5 @@
 # Patchman server
-server=https://patchman.example.com
+server=http://patchman.example.com
 
 # Options to curl
 curl_options="--insecure --connect-timeout 60 --max-time 300"


### PR DESCRIPTION
… not enable https.  This was a little confusing on first setup.